### PR TITLE
Patch for MultipartEncodedDataProcessor

### DIFF
--- a/feign-form/src/main/java/feign/form/MultipartEncodedDataProcessor
+++ b/feign-form/src/main/java/feign/form/MultipartEncodedDataProcessor
@@ -1,0 +1,202 @@
+public class MultipartEncodedDataProcessor implements FormDataProcessor {
+    public static final String CONTENT_TYPE;
+    private static final String CRLF;
+
+    static {
+        CONTENT_TYPE = "multipart/form-data";
+        CRLF = "\r\n";
+    }
+
+    private final List<HttpMessageConverter<?>> converters = new RestTemplate().getMessageConverters();
+
+    @Override
+    @SneakyThrows
+    @SuppressWarnings("unchecked")
+    public void process(Map<String, Object> data, RequestTemplate template) {
+        val boundary = createBoundary();
+        val outputStream = new ByteArrayOutputStream();
+
+        try {
+            val writer = new PrintWriter(outputStream);
+            for (Map.Entry<String, Object> entry : data.entrySet()) {
+                writer.append("--" + boundary).append(CRLF);
+
+                if (isPayload(entry.getValue())) { // check if it is a file
+                                                   // object, list of object a
+                                                   // byte array
+                    if (entry.getValue() instanceof List<?>) {
+                        int size = ((List) entry.getValue()).size();
+                        int index = 1;
+                        for (Object listContent : (List<Object>) entry.getValue()) {
+                                writeByteOrFile(outputStream, writer, entry.getKey(), listContent);
+                            if (index < size) {
+                                writer.append(CRLF).append("--" + boundary).append(CRLF).flush();
+                            }
+                            index++;
+                        }
+
+                    } else {
+                        writeByteOrFile(outputStream, writer, entry.getKey(), entry.getValue());
+                    }
+
+                } else {
+                    // entry.getValue() must be serializable
+                    writeParameter(writer, entry.getKey(), new ObjectMapper().writeValueAsString(entry.getValue()));
+                }
+                writer.append(CRLF).flush();
+            }
+
+            writer.append("--")
+                    .append(boundary)
+                    .append("--")
+                    .append(CRLF)
+                    .flush();
+
+        } catch (Throwable throwable) {
+            try {
+                outputStream.close();
+            } catch (IOException ex) {
+
+            }
+            throw throwable;
+        }
+
+        val contentType = CONTENT_TYPE + "; boundary=" + boundary;
+        template.header("Content-Type", contentType);
+        template.body(outputStream.toByteArray(), UTF_8);
+        outputStream.close();
+    }
+
+
+    @Override
+    public String getSupportetContentType() {
+        return CONTENT_TYPE;
+    }
+
+    /**
+     * Checks is passed object a supported file's type or not.
+     *
+     * @param value
+     *            form file parameter.
+     */
+    protected boolean isPayload(Object value) {
+        return value != null && (value instanceof File || value instanceof byte[] || value instanceof List<?>);
+    }
+
+
+    /**
+     * Writes file's content to output stream.
+     *
+     * @param output
+     *            output stream to remote destination.
+     * @param writer
+     *            wrapped output stream.
+     * @param name
+     *            the name of the file.
+     * @param value
+     *            file's content. Byte array or {@link File}.
+     */
+    protected void writeByteOrFile(OutputStream output, PrintWriter writer, String name, Object value) {
+
+        if (value instanceof byte[]) {
+            writeByteArray(output, writer, name, null, null, (byte[]) value);
+        } else {
+            writeFile(output, writer, name, null, (File) value);
+        }
+    }
+
+    private String createBoundary() {
+        return Long.toHexString(System.currentTimeMillis());
+    }
+
+    private void writeParameter(PrintWriter writer, String name, String value) {
+        writer.append("Content-Disposition: form-data; name=\"" + name + "\"").append(CRLF);
+        writer.append("Content-Type: application/json; charset=UTF-8").append(CRLF);
+        writer.append(CRLF).append(value);
+    }
+
+    /**
+     * Writes file to output stream as a {@link File}.
+     *
+     * @param output
+     *            output stream to remote destination.
+     * @param writer
+     *            wrapped output stream.
+     * @param name
+     *            the name of the file.
+     * @param contentType
+     *            the content type (if known).
+     * @param file
+     *            file object.
+     */
+    @SneakyThrows
+    protected void writeFile(OutputStream output, PrintWriter writer, String name, String contentType, File file) {
+        writeFileMeta(writer, name, file.getName(), contentType);
+
+        InputStream input = null;
+        try {
+            input = new FileInputStream(file);
+            byte[] buffer = new byte[1024];
+            int length;
+            while ((length = input.read(buffer)) > 0) {
+                output.write(buffer, 0, length);
+            }
+        } finally {
+            if (input != null) {
+                input.close();
+            }
+        }
+        writer.flush();
+    }
+
+    /**
+     * Writes file's content to output stream as a byte array.
+     *
+     * @param output
+     *            utput stream to remote destination.
+     * @param writer
+     *            wrapped output stream.
+     * @param name
+     *            the name of the file.
+     * @param originalFilename
+     *            the original filename (as on the client's machine).
+     * @param contentType
+     *            the content type (if known).
+     * @param bytes
+     *            file's content.
+     */
+    @SneakyThrows
+    protected void writeByteArray(OutputStream output,
+            PrintWriter writer,
+            String name,
+            String originalFilename,
+            String contentType,
+            byte[] bytes) {
+        writeFileMeta(writer, name, originalFilename, contentType);
+        output.write(bytes);
+        writer.flush();
+    }
+
+    private void writeFileMeta(PrintWriter writer, String name, String fileName, String contentValue) {
+        val contentDesposition = new StringBuilder()
+                .append("Content-Disposition: form-data; name=\"").append(name).append("\"; ")
+                .append("filename=\"").append(fileName).append("\"")
+                .toString();
+
+        if (contentValue == null) {
+            contentValue = fileName != null
+                    ? URLConnection.guessContentTypeFromName(fileName)
+                    : "application/octet-stream";
+        }
+        val contentType = new StringBuilder()
+                .append("Content-Type: ")
+                .append(contentValue)
+                .toString();
+
+        writer.append(contentDesposition).append(CRLF);
+        writer.append(contentType).append(CRLF);
+        writer.append("Content-Transfer-Encoding: binary").append(CRLF);
+        writer.append(CRLF).flush();
+    }
+
+}


### PR DESCRIPTION
This is a minor enhancement of the MultipartEncodedDataProcessor enabling the sending of POJOs (as json string instead of plain text) and List of Files as well.